### PR TITLE
fix(entry): without ssr load client as eager

### DIFF
--- a/example/nuxt.config.js
+++ b/example/nuxt.config.js
@@ -154,8 +154,7 @@ module.exports = {
   buildModules: [
     '@nuxt/postcss8',
     '@nuxtjs/eslint-module',
-    '@nuxtjs/stylelint-module',
-    '@nuxt/image'
+    '@nuxtjs/stylelint-module'
   ].filter(v => v),
 
   speedkit: {

--- a/lib/module.js
+++ b/lib/module.js
@@ -76,7 +76,7 @@ async function addBuildTemplates (scope, options) {
   scope.addTemplate({
     src: path.resolve(__dirname, 'templates/entry.js'),
     fileName: pkg.name + '/entry.js',
-    options: { ignorePerformance: !options.detection.performance, performanceMetrics: JSON.stringify(options.performanceMetrics || {}), supportedBrowserDetector }
+    options: { ssr: scope.nuxt.options.ssr, ignorePerformance: !options.detection.performance, performanceMetrics: JSON.stringify(options.performanceMetrics || {}), supportedBrowserDetector }
   });
 
   scope.addTemplate({

--- a/lib/templates/entry.js
+++ b/lib/templates/entry.js
@@ -10,7 +10,7 @@ async function initApp() {
   init = true;
 
   await new Promise(resolve => waitForIdle(resolve));
-  return import('../client');
+  return import(<% if (!options.ssr) { %>/* webpackMode: "eager" */<% } %>'../client');
 };
 
 function waitForIdle (cb) {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
If `ssr` is disabled, the `client.js` is imported via eager in the entry.

* **What is the new behavior (if this is a feature change)?**
If `ssr` is not active the initial scripts contain the `client.js` import.
