### PR TITLE
fix(head): remove merge strategy override

### DIFF
--- a/docs/content/v2/en/caveats.md
+++ b/docs/content/v2/en/caveats.md
@@ -14,7 +14,7 @@ By passing the `headAddition` argument, additional head settings can be applied.
 
 <alert type="warning">`$speedkit.head()` is only available in vue component scope.</alert>
 
-#### Example:
+### Example
 
 ````html
 <template>
@@ -38,6 +38,9 @@ By passing the `headAddition` argument, additional head settings can be applied.
   }
 </script>
 ````
+
+### Issues
+- https://github.com/nuxt/vue-meta/issues/695
 ## Browser compatibility
 
 You can use `nuxt-speedkit` with **Internet Explorer 11** browser. 

--- a/lib/plugins/vFont/head.js
+++ b/lib/plugins/vFont/head.js
@@ -1,4 +1,3 @@
-import Vue from 'vue';
 import merge from 'deepmerge';
 
 const pageStyles = { prev: new Map(), current: new Map() };
@@ -51,5 +50,3 @@ export const head = function (headAddition) {
     arrayMerge: arrayConcatMerge
   });
 };
-
-Vue.config.optionMergeStrategies.head = Vue.config.optionMergeStrategies.data;


### PR DESCRIPTION
Removes the override of the head merge strategy.

- [x] SSR markup is identical with and without
- [x] No misbehaviors found in the client.

Overwriting will cause wrong behavior if `null`/`undefined` is returned in the head.