### PR TITLE
fix(entry): added idle loop break;

### DIFF
--- a/docs/content/v2/en/migration/v2.0.13.md
+++ b/docs/content/v2/en/migration/v2.0.13.md
@@ -35,3 +35,15 @@ replaced with
   bad performance
 </li>
 ```
+
+## SpeedkitLayer Button Interactions
+
+Button `#nuxt-speedkit-button-init-font` has been replaced by `#nuxt-speedkit-button-init-performance-issue`.
+
+`#nuxt-speedkit-button-init-performance-issue` does the following when clicked:
+
+1. Sets the CSS class `nuxt-speedkit-performance-issue` on the `html` tag.
+2. Activates all fonts by setting the class `font-active` on all elements with the attribute `data-font`.
+3. Converts all not activated pictures (`:hydrate="false"`) from `noscript` to `picture`. This is done by setting HTML in the parent element. 
+
+<alert>The CSS class `nuxt-speedkit-performance-issue` is removed again at app initialization.</alert>

--- a/docs/content/v2/en/migration/v2.0.13.md
+++ b/docs/content/v2/en/migration/v2.0.13.md
@@ -44,6 +44,6 @@ Button `#nuxt-speedkit-button-init-font` has been replaced by `#nuxt-speedkit-bu
 
 1. Sets the CSS class `nuxt-speedkit-performance-issue` on the `html` tag.
 2. Activates all fonts by setting the class `font-active` on all elements with the attribute `data-font`.
-3. Converts all not activated pictures (`:hydrate="false"`) from `noscript` to `picture`. This is done by setting HTML in the parent element. 
+3. Converts all not activated pictures (`:hydrate="false"`) from `noscript` to `picture`. 
 
 <alert>The CSS class `nuxt-speedkit-performance-issue` is removed again at app initialization.</alert>

--- a/example/components/InfoLayer.vue
+++ b/example/components/InfoLayer.vue
@@ -24,7 +24,7 @@
             OK
           </label>
         </base-button>
-        <base-button id="nuxt-speedkit-button-init-font" onclick="window.__NUXT_SPEEDKIT_FONT_INIT__ = true;">
+        <base-button id="nuxt-speedkit-button-init-performance-issue" onclick="window.__NUXT_SPEEDKIT_PERFORMANCE_ISSUE_INIT__ = true;">
           <label for="nuxt-speedkit-layer-close">
             No
           </label>

--- a/lib/components/SpeedkitLayer.vue
+++ b/lib/components/SpeedkitLayer.vue
@@ -21,8 +21,8 @@
                 slow connection
               </li>
               <!-- Displayed when by bad perforamce. -->
-              <li id="nuxt-speedkit-message-bad-performance">
-                basd performance
+              <li id="nuxt-speedkit-message-performance-issue">
+                performance issue
               </li>
             </ul>
 
@@ -34,11 +34,11 @@
             </button>
 
             <!-- Button for use without javascript and with fonts -->
-            <button id="nuxt-speedkit-button-init-font" onclick="window.__NUXT_SPEEDKIT_FONT_INIT__ = true;">
+            <base-button id="nuxt-speedkit-button-init-performance-issue" onclick="window.__NUXT_SPEEDKIT_PERFORMANCE_ISSUE_INIT__ = true;">
               <label for="nuxt-speedkit-layer-close">
-                Apply with Fonts
+                Apply without scripts
               </label>
-            </button>
+            </base-button>
 
             <!-- Button for activate javascript by bad connection or browser support -->
             <button id="nuxt-speedkit-button-init-app" onclick="window.__NUXT_SPEEDKIT_AUTO_INIT__ = true;">
@@ -114,7 +114,7 @@ export default {
   display: none;
 }
 
-#nuxt-speedkit-message-bad-performance {
+#nuxt-speedkit-message-performance-issue {
   display: none;
 }
 

--- a/lib/components/SpeedkitPicture.vue
+++ b/lib/components/SpeedkitPicture.vue
@@ -15,7 +15,9 @@ export default {
   render (h) {
     if (!this.hydrate) {
       return h(LazyHydrate, { props: { never: true } }, [
-        h('noscript', {}, [
+        h('noscript', {
+          class: 'nuxt-speedkit-picture-noscript'
+        }, [
           h(SpeedkitPicture, { props: { ...this.$attrs, critical: this.hydrate }, on: this.$listeners })
         ])
       ]);

--- a/lib/templates/entry.js
+++ b/lib/templates/entry.js
@@ -66,8 +66,11 @@ function initPerformanceIssue () {
   })
 
   // transform noscript>picture to picture
-  Array.from(document.querySelectorAll('noscript.picture-no-script')).forEach(el => {
-    el.parentNode.innerHTML = el.innerHTML;
+  Array.from(document.querySelectorAll('noscript.nuxt-speedkit-picture-noscript')).forEach(el => {
+    const tmp = document.createElement('div');
+    tmp.innerHTML = el.innerHTML;
+    el.parentNode.replaceChild(tmp.children[0], el);
+    tmp.remove();
   })
 }
 

--- a/lib/templates/entry.js
+++ b/lib/templates/entry.js
@@ -1,7 +1,7 @@
 import { hasSufficientPerformance, hasSufficientDownloadPerformance, setup } from 'nuxt-speedkit/utils/performance';
 import { isSupportedBrowser } from 'nuxt-speedkit/utils/browser';
 
-const MAX_IDLE_TRYS = 1000;
+const MAX_IDLE_TRIES = 1000; // 1000 / 60 = 16 seconds
 let init = false
 const layerEl = global.document.getElementById('nuxt-speedkit-layer');
 
@@ -18,14 +18,14 @@ async function initApp(force) {
   return null;
 };
 
-let idleTrys = 0;
+let idleTries = 0;
 function waitForIdle (cb) {
-  if (!!layerEl && idleTrys >= MAX_IDLE_TRYS) {
+  if (!!layerEl && idleTries >= MAX_IDLE_TRIES) {
     // User must interact via the layer.
     updateInfoLayerMessage('nuxt-speedkit-message-performance-issue');
     cb(false);
-  } else if ('requestIdleCallback' in global &&  MAX_IDLE_TRYS > idleTrys) {
-    idleTrys++
+  } else if ('requestIdleCallback' in global &&  MAX_IDLE_TRIES > idleTries) {
+    idleTries++
     global.requestIdleCallback((deadline) => {
       const time = deadline.timeRemaining();
       if (time > 10 || deadline.didTimeout) {
@@ -38,12 +38,6 @@ function waitForIdle (cb) {
     cb(true);
   }
 };
-
-function initFont() {
-  global.document.querySelectorAll('[data-font]').forEach((node) => {
-    node.classList.add('font-active');
-  })
-}
 
 function observeSpeedkitButton (id, callback) {
   Array.from(document.querySelectorAll(`#${id}`)).forEach(el => {
@@ -64,7 +58,10 @@ function updateInfoLayerMessage(id) {
 function initPerformanceIssue () {
   document.documentElement.classList.add('nuxt-speedkit-performance-issue');
 
-  initFont();
+  // activate fonts
+  global.document.querySelectorAll('[data-font]').forEach((node) => {
+    node.classList.add('font-active');
+  })
 
   // transform noscript>picture to picture
   Array.from(document.querySelectorAll('noscript.picture-no-script')).forEach(el => {
@@ -85,7 +82,6 @@ function setupSpeedkitLayer(callback, supportedBrowser) {
     updateInfoLayerMessage('nuxt-speedkit-message-slow-connection');
   }
   observeSpeedkitButton('nuxt-speedkit-button-init-app', callback);
-  observeSpeedkitButton('nuxt-speedkit-button-init-performance-issue', initPerformanceIssue);
 }
 
 const supportedBrowser = isSupportedBrowser(<%= options.supportedBrowserDetector %>);
@@ -98,10 +94,8 @@ if (!document.getElementById('nuxt-speedkit-layer')) {
 
   if(('__NUXT_SPEEDKIT_AUTO_INIT__' in global && global.__NUXT_SPEEDKIT_AUTO_INIT__) || ((<%= !options.ignorePerformance %> && hasSufficientPerformance()) && supportedBrowser)) {
     initApp();
-  } else if('__NUXT_SPEEDKIT_FONT_INIT__' in global && global.__NUXT_SPEEDKIT_FONT_INIT__) {
-    initFont()
   } else {
-    observeSpeedkitButton('nuxt-speedkit-button-init-font', initFont);
+    observeSpeedkitButton('nuxt-speedkit-button-init-performance-issue', initPerformanceIssue);
     setupSpeedkitLayer(() => initApp(true), supportedBrowser)
   }
 

--- a/lib/templates/entry.js
+++ b/lib/templates/entry.js
@@ -69,20 +69,17 @@ function initPerformanceIssue () {
   Array.from(document.querySelectorAll('noscript.picture-no-script')).forEach(el => {
     el.parentNode.innerHTML = el.innerHTML;
   })
-
-  observeSpeedkitButton('nuxt-speedkit-button-init-app', () => {
-    initApp(true);
-  });
 }
 
-function setupSpeedkitLayer(callback, supportedBrowser) {
+function setupSpeedkitLayer(supportedBrowser) {
   if(!supportedBrowser) {
     updateInfoLayerMessage('nuxt-speedkit-message-unsupported-browser');
   }
   if(!hasSufficientDownloadPerformance()) {
     updateInfoLayerMessage('nuxt-speedkit-message-slow-connection');
   }
-  observeSpeedkitButton('nuxt-speedkit-button-init-app', callback);
+  observeSpeedkitButton('nuxt-speedkit-button-init-performance-issue', initPerformanceIssue);
+  observeSpeedkitButton('nuxt-speedkit-button-init-app', () => initApp(true));
 }
 
 const supportedBrowser = isSupportedBrowser(<%= options.supportedBrowserDetector %>);
@@ -96,8 +93,7 @@ if (!document.getElementById('nuxt-speedkit-layer')) {
   if(('__NUXT_SPEEDKIT_AUTO_INIT__' in global && global.__NUXT_SPEEDKIT_AUTO_INIT__) || ((<%= !options.ignorePerformance %> && hasSufficientPerformance()) && supportedBrowser)) {
     initApp();
   } else {
-    observeSpeedkitButton('nuxt-speedkit-button-init-performance-issue', initPerformanceIssue);
-    setupSpeedkitLayer(() => initApp(true), supportedBrowser)
+    setupSpeedkitLayer(supportedBrowser)
   }
 
 }

--- a/lib/templates/entry.js
+++ b/lib/templates/entry.js
@@ -1,30 +1,41 @@
 import { hasSufficientPerformance, hasSufficientDownloadPerformance, setup } from 'nuxt-speedkit/utils/performance';
 import { isSupportedBrowser } from 'nuxt-speedkit/utils/browser';
 
+const MAX_IDLE_TRYS = 1000;
 let init = false
+const layerEl = global.document.getElementById('nuxt-speedkit-layer');
 
-async function initApp() {
+async function initApp(force) {
   if (init) {
     return;
   }
-  init = true;
 
-  await new Promise(resolve => waitForIdle(resolve));
-  return import(<% if (!options.ssr) { %>/* webpackMode: "eager" */<% } %>'../client');
+  init = force || await new Promise(resolve => waitForIdle(resolve));
+  if (init) {
+    return import(<% if (!options.ssr) { %>/* webpackMode: "eager" */<% } %>'../client');
+  }
+
+  return null;
 };
 
+let idleTrys = 0;
 function waitForIdle (cb) {
-  if ('requestIdleCallback' in global) {
+  if (!!layerEl && idleTrys >= MAX_IDLE_TRYS) {
+    // User must interact via the layer.
+    updateInfoLayerMessage('nuxt-speedkit-message-performance-issue');
+    cb(false);
+  } else if ('requestIdleCallback' in global &&  MAX_IDLE_TRYS > idleTrys) {
+    idleTrys++
     global.requestIdleCallback((deadline) => {
       const time = deadline.timeRemaining();
       if (time > 10 || deadline.didTimeout) {
-        cb();
+        cb(true);
       } else {
         waitForIdle(cb);
       }
     }, { timeout: 2000 });
   } else {
-    cb();
+    cb(true);
   }
 };
 
@@ -34,25 +45,47 @@ function initFont() {
   })
 }
 
-function observeSpeedkitButton (button, callback) {
-  if (button) {
-    button.addEventListener('click', callback, { capture: true, once: true, passive: true })
+function observeSpeedkitButton (id, callback) {
+  Array.from(document.querySelectorAll(`#${id}`)).forEach(el => {
+    el.addEventListener('click', callback, { capture: true, once: true, passive: true })
+  })
+}
+
+function updateInfoLayerMessage(id) {
+  const el = global.document.getElementById(id)
+  if (!el) {
+    throw new Error(`Can\'t update info layer, message ${id} missing.`);
+  } else {
+    el.style.display = 'block'
+    layerEl.className += ' nuxt-speedkit-layer-visible';
   }
 }
 
-function updateInfoLayer(item) {
-  item.style.display = 'block'
-  global.document.querySelector('#nuxt-speedkit-layer').className += ' nuxt-speedkit-layer-visible';
+function initPerformanceIssue () {
+  document.documentElement.classList.add('nuxt-speedkit-performance-issue');
+
+  initFont();
+
+  // transform noscript>picture to picture
+  Array.from(document.querySelectorAll('noscript.picture-no-script')).forEach(el => {
+    el.parentNode.innerHTML = el.innerHTML;
+  })
+
+  observeSpeedkitButton('nuxt-speedkit-button-init-app', () => {
+    initApp(true);
+    document.documentElement.classList.remove('nuxt-speedkit-performance-issue');
+  });
 }
 
 function setupSpeedkitLayer(callback, supportedBrowser) {
   if(!supportedBrowser) {
-    updateInfoLayer(global.document.getElementById('nuxt-speedkit-message-unsupported-browser'));
+    updateInfoLayerMessage('nuxt-speedkit-message-unsupported-browser');
   }
   if(!hasSufficientDownloadPerformance()) {
-    updateInfoLayer(global.document.getElementById('nuxt-speedkit-message-slow-connection'));
+    updateInfoLayerMessage('nuxt-speedkit-message-slow-connection');
   }
-  observeSpeedkitButton(global.document.getElementById('nuxt-speedkit-button-init-app'), callback);
+  observeSpeedkitButton('nuxt-speedkit-button-init-app', callback);
+  observeSpeedkitButton('nuxt-speedkit-button-init-performance-issue', initPerformanceIssue);
 }
 
 const supportedBrowser = isSupportedBrowser(<%= options.supportedBrowserDetector %>);
@@ -63,16 +96,13 @@ if (!document.getElementById('nuxt-speedkit-layer')) {
 
   setup(<%= options.performanceMetrics %>);
 
-  setupSpeedkitLayer(initApp, supportedBrowser)
-
   if(('__NUXT_SPEEDKIT_AUTO_INIT__' in global && global.__NUXT_SPEEDKIT_AUTO_INIT__) || ((<%= !options.ignorePerformance %> && hasSufficientPerformance()) && supportedBrowser)) {
     initApp();
-  }
-
-  observeSpeedkitButton(global.document.getElementById('nuxt-speedkit-button-init-font'), initFont);
-
-  if('__NUXT_SPEEDKIT_FONT_INIT__' in global && global.__NUXT_SPEEDKIT_FONT_INIT__) {
+  } else if('__NUXT_SPEEDKIT_FONT_INIT__' in global && global.__NUXT_SPEEDKIT_FONT_INIT__) {
     initFont()
+  } else {
+    observeSpeedkitButton('nuxt-speedkit-button-init-font', initFont);
+    setupSpeedkitLayer(() => initApp(true), supportedBrowser)
   }
 
 }

--- a/lib/templates/entry.js
+++ b/lib/templates/entry.js
@@ -10,6 +10,8 @@ async function initApp(force) {
     return;
   }
 
+  document.documentElement.classList.remove('nuxt-speedkit-performance-issue');
+
   init = force || await new Promise(resolve => waitForIdle(resolve));
   if (init) {
     return import(<% if (!options.ssr) { %>/* webpackMode: "eager" */<% } %>'../client');
@@ -70,7 +72,6 @@ function initPerformanceIssue () {
 
   observeSpeedkitButton('nuxt-speedkit-button-init-app', () => {
     initApp(true);
-    document.documentElement.classList.remove('nuxt-speedkit-performance-issue');
   });
 }
 


### PR DESCRIPTION
## Entry
- Idle loop termination added. Number is defined with `MAX_IDLE_TRYS`.
- New activation function for element `#nuxt-speedkit-button-init-performance-issue` -> `initPerformanceIssue`.
- Revision of dom `id` passing `updateInfoLayerMessage` & `observeSpeedkitButton`.

## SpeedkitLayer

- Added new layer message `nuxt-speedkit-message-performance-issue`.
- "Font only" action has been removed, it is enough to choose between:
  1. page will be executed normally (`#nuxt-speedkit-button-init-app`)
  2. or scripts are not initialized.  (`#nuxt-speedkit-button-init-performance-issue`)
      - Sets the CSS class `nuxt-speedkit-performance-issue` on the `html` tag.
      - Activates all fonts by setting the class `font-active` on all elements with the attribute `data-font`.
      - Converts all not activated pictures (`:hydrate="false"`) from `noscript` to `picture`. 


