### PR TITLE
fix(entry): max idle tries can be set via modul option

### DIFF
--- a/docs/content/v2/en/options.md
+++ b/docs/content/v2/en/options.md
@@ -291,3 +291,13 @@ Defines the global built-in [LoadingSpinner](/components/speedkit-image#loadings
  | `size`            | `String` | no       | Defines the size of the loader. Use css `background-size` definition.         | `100px`     |
  | `backgroundColor` | `String` | no       | Defines the background color of the loader. Use css `color` definition.       | `grey`      |
 
+## `maxIdleTries`
+- Type: `Number`
+  - Default: `1000`
+
+Sets the number of times `IdleDeadline.timeRemaining()` is called, the retrieved period must be at least `10ms`.
+
+When reaching the max. value, 
+
+- the SpeedkitLayer is shown if available or the app is 
+- or the app is initialized automatically.

--- a/example/components/InfoLayer.vue
+++ b/example/components/InfoLayer.vue
@@ -14,14 +14,14 @@
         <li id="nuxt-speedkit-message-slow-connection">
           slow connection
         </li>
-        <li id="nuxt-speedkit-message-bad-performance">
+        <li id="nuxt-speedkit-message-performance-issue">
           bad performance
         </li>
       </ul>
       <div class="info-layer-buttons">
         <base-button id="nuxt-speedkit-button-init-nojs">
           <label for="nuxt-speedkit-layer-close">
-            OK
+            Yes
           </label>
         </base-button>
         <base-button id="nuxt-speedkit-button-init-performance-issue" onclick="window.__NUXT_SPEEDKIT_PERFORMANCE_ISSUE_INIT__ = true;">

--- a/example/components/organisms/ImageText.vue
+++ b/example/components/organisms/ImageText.vue
@@ -13,6 +13,7 @@
           :title="picture.title"
           :alt="picture.alt"
           :sources="picture.sources"
+          :hydrate="picture.hydrate !== undefined ? picture.hydrate : true"
         />
       </div>
       <div class="text">

--- a/example/pages/tests/speedkit-layer/index.vue
+++ b/example/pages/tests/speedkit-layer/index.vue
@@ -1,0 +1,48 @@
+<template>
+  <document-section tag="main">
+    <component-image-text v-bind="imageTextA" />
+    <speedkit-layer />
+  </document-section>
+</template>
+
+<script>
+import speedkitHydrate from 'nuxt-speedkit/hydrate';
+import SpeedkitLayer from 'nuxt-speedkit/components/SpeedkitLayer';
+
+export default {
+  layout: 'blank',
+
+  components: {
+    SpeedkitLayer,
+    ComponentImageText: speedkitHydrate(() => import('@/components/organisms/ImageText'))
+  },
+
+  data () {
+    return {
+      pictureHydrate: false
+
+    };
+  },
+
+  computed: {
+    imageTextA () {
+      return {
+        headline: 'SpeedkitLayer Test',
+        content: '<p>Aliqua odit anim vehicula varius eget feugiat beatae. Fringilla cumque, nulla pulvinar necessitatibus pharetra vehicula ultricies egestas rhoncus justo occaecati amet, fames quod. Similique! Ornare nesciunt inventore nulla, montes doloribus, erat, parturient! Accumsan omnis doloribus perspiciatis, blanditiis ullamcorper adipisicing quisquam. Nobis placerat. Eget do sagittis elit wisi voluptates, facilisis veritatis.</p><p>Laboriosam recusandae blandit nunc tempor urna veniam? Etiam perferendis, quisquam class ea eos habitasse quis tempora nulla? Non, facilis consectetuer suspendisse tortor, etiam dolor? Blanditiis suspendisse, massa. Tempus consequatur bibendum magnam? Praesentium, posuere consequuntur, tenetur tempus quod suscipit nibh? Voluptate ratione justo! Ullamcorper! Cursus auctor magna. Beatae corporis. Inceptos nisi.</p>',
+        picture: {
+          hydrate: this.pictureHydrate,
+          title: 'SpeedkitLayer Test',
+          sources: [
+            // eslint-disable-next-line no-secrets/no-secrets
+            { src: '/img/pickadummy/image-text-a.jpg', sizes: { default: '100vw', xxs: '100vw', xs: '100vw', sm: '100vw', md: '100vw', lg: '100vw', xl: '100vw', xxl: '100vw' } }
+          ]
+        }
+      };
+    }
+  },
+  mounted () {
+    this.pictureHydrate = true;
+  }
+
+};
+</script>

--- a/lib/module.js
+++ b/lib/module.js
@@ -83,7 +83,13 @@ async function addBuildTemplates (scope, options) {
   scope.addTemplate({
     src: path.resolve(__dirname, 'templates/entry.js'),
     fileName: pkg.name + '/entry.js',
-    options: { ssr: scope.nuxt.options.ssr, ignorePerformance: !options.detection.performance, performanceMetrics: JSON.stringify(options.performanceMetrics || {}), supportedBrowserDetector }
+    options: {
+      maxIdleTries: options.maxIdleTries,
+      ssr: scope.nuxt.options.ssr,
+      ignorePerformance: !options.detection.performance,
+      performanceMetrics: JSON.stringify(options.performanceMetrics || {}),
+      supportedBrowserDetector
+    }
   });
 
   scope.addTemplate({

--- a/lib/module/utils.js
+++ b/lib/module/utils.js
@@ -22,8 +22,6 @@ function getOptions (options) {
 
   options = defu(options, {
 
-    maxIdleTries: 1000, // 1000 / 60 = 16 seconds
-
     optimizePreloads: true,
 
     detection: {
@@ -57,7 +55,9 @@ function getOptions (options) {
       dataUri: undefined,
       size: '100px',
       backgroundColor: 'grey'
-    }
+    },
+
+    maxIdleTries: 1000 // 1000 / 60 = 16 seconds
   });
   options.targetFormats = options.targetFormats || DEFAULT_TARGET_FORMATS;
   return options;

--- a/lib/module/utils.js
+++ b/lib/module/utils.js
@@ -22,6 +22,8 @@ function getOptions (options) {
 
   options = defu(options, {
 
+    maxIdleTries: 1000, // 1000 / 60 = 16 seconds
+
     optimizePreloads: true,
 
     detection: {

--- a/lib/templates/entry.js
+++ b/lib/templates/entry.js
@@ -1,7 +1,7 @@
 import { hasSufficientPerformance, hasSufficientDownloadPerformance, setup } from 'nuxt-speedkit/utils/performance';
 import { isSupportedBrowser } from 'nuxt-speedkit/utils/browser';
 
-const MAX_IDLE_TRIES = 1000; // 1000 / 60 = 16 seconds
+const MAX_IDLE_TRIES = <%= options.maxIdleTries %>;
 let init = false
 const layerEl = global.document.getElementById('nuxt-speedkit-layer');
 
@@ -81,8 +81,6 @@ function setupSpeedkitLayer(supportedBrowser) {
   if(!hasSufficientDownloadPerformance()) {
     updateInfoLayerMessage('nuxt-speedkit-message-slow-connection');
   }
-  observeSpeedkitButton('nuxt-speedkit-button-init-performance-issue', initPerformanceIssue);
-  observeSpeedkitButton('nuxt-speedkit-button-init-app', () => initApp(true));
 }
 
 const supportedBrowser = isSupportedBrowser(<%= options.supportedBrowserDetector %>);
@@ -90,6 +88,9 @@ const supportedBrowser = isSupportedBrowser(<%= options.supportedBrowserDetector
 if (!document.getElementById('nuxt-speedkit-layer')) {
   initApp();
 } else {
+
+  observeSpeedkitButton('nuxt-speedkit-button-init-performance-issue', initPerformanceIssue);
+  observeSpeedkitButton('nuxt-speedkit-button-init-app', () => initApp(true));
 
   setup(<%= options.performanceMetrics %>);
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -22,6 +22,9 @@ export const generate = async (buildDir, distDir) => {
     generate: { cache: false, dir: distDir, crawler: false },
     dir: {
       pages: 'pages/tests'
+    },
+    speedkit: {
+      maxIdleTries: 0
     }
   }, nuxtConfig);
   const nuxt = new Nuxt(config);


### PR DESCRIPTION
## Module

- added Option `maxIdleTries` for define max idle tries via module options.

## Tests
- Added tests for `speedkit-layer` interaction
  - Apply without scripts
  - Apply with scripts
  - No Javascript

## Sample
- Fix ids
- Prepare ImageText for picture hydrate option
- Added test page `/tests/speedkit-layer/`

## Docs
- Added option `maxIdleTries`