### PR TITLE
fix(weak-hardware): add overlay for `weak hardware`

### DIFF
--- a/docs/content/v2/en/components/speedkit-vimeo.md
+++ b/docs/content/v2/en/components/speedkit-vimeo.md
@@ -148,7 +148,8 @@ This is important for autoplay on mobile devices.
 | `default`         | Used to display more information about the video below the player.<br>The slot has a scoped property `videoData`. <br>This contains the result from the Vimeo `oembed` api.<br><br>https://developer.vimeo.com/api/oembed/videos#table-2 |
 | `loading-spinner` | Overwrites the loading spinner.                                                                                                                                                                                                          |
 | `play`            | Overwrites the play button.                                                                                                                                                                                                              |
-
+| `beforePlayer`    | Used to place elements in the player container (before).                                                                                                                                                                                 |
+| `afterPlayer`     | Used to place elements in the player container (after).                                                                                                                                                                                  |
 
 ## Events
 

--- a/docs/content/v2/en/components/speedkit-youtube.md
+++ b/docs/content/v2/en/components/speedkit-youtube.md
@@ -148,10 +148,12 @@ Sets the host for the player.
 </template>
 ````
 
-| Name              | Description                     |
-| ----------------- | ------------------------------- |
-| `loading-spinner` | Overwrites the loading spinner. |
-| `play`            | Overwrites the play button.     |
+| Name              | Description                                              |
+| ----------------- | -------------------------------------------------------- |
+| `loading-spinner` | Overwrites the loading spinner.                          |
+| `play`            | Overwrites the play button.                              |
+| `beforePlayer`    | Used to place elements in the player container (before). |
+| `afterPlayer`     | Used to place elements in the player container (after).  |
 
 ## Events
 

--- a/docs/content/v2/en/components/weak-hardware-overlay.md
+++ b/docs/content/v2/en/components/weak-hardware-overlay.md
@@ -1,0 +1,103 @@
+---
+title: WeakHardwareOverlay
+description: ''
+position: 336
+category: Components
+
+---
+
+Der `PerformanceIssueOverlay` findet seinen Einsatz in Komponenten die vom SpeedkitLayer Ereignis `Weak Hardware` beeinträchtigt werden. (*Beispiel: Komponente benötigt das ausführen von `mounted` für funktionialität.*)
+
+> 
+
+<alert>
+Das <strong>Performance Issue Ereignis</strong> tritt ein wenn bei der Initialisierung ermittelt wurde, dass der Client mit der Ausführung überlastet ist und der Benutzer im SpeedkitLayer den Button <strong>#nuxt-speedkit-button-init-reduced-view</strong> bestätigt hat.
+
+- [Mehr erfahren zu SpeedkitLayer Interaktionen)](/components/speedkit-layer#buttons)
+</alert>
+
+
+Grundsätzlich wird das Overlay verwendet um Inhalt sichtbar zu machen wenn das `Weak Hardware` eingetreten ist, tritt dieses nicht ein, ist das Overlay nicht sichtbar.
+
+Es wird empfohlen ein Interaktions-Element im Overlay zu verbauen, das dem Benutzer die möglichkeit bietet in den normalen Zustand zu wechseln. Hierfür muss das Interaktions-Element die ID `nuxt-speedkit-button-init-app` bekommen und reagiert somit auf `click` mit dem initialisieren der App.
+
+## Example
+
+Beispiel für das definieren einer benutzerdefinierten `WeakHardwareOverlay` Komponente und deren einbau in einer Ziel Komponente die vom Ereignis `Weak Hardware` beeinträchtigt ist.
+
+### Customize Overlay
+
+````vue[@/components/WeakHardwareOverlay.vue]
+<template>
+  <speedkit-weak-hardware-overlay>
+    To improve your experience, extensive features have been disabled.<br>
+    <button id="nuxt-speedkit-button-init-app">
+     Click here to enable them.
+    </button>
+  </speedkit-weak-hardware-overlay>
+</template>
+
+<script>
+
+import SpeedkitWeakHardwareOverlay from 'nuxt-speedkit/components/WeakHardwareOverlay';
+export default {
+  components: { SpeedkitWeakHardwareOverlay }
+};
+
+</script>
+
+<style lang="postcss" scoped>
+.nuxt-speedkit-weak-hardware-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgb(0 0 0 / 60%);
+  backdrop-filter: blur(em(2px));
+}
+</style>
+````
+
+
+
+### Usage Overlay
+
+````vue[@/components/Player.vue]
+<template>
+  <div>
+    <div ref="player" />
+    <weak-hardware-overlay />
+  </div>
+</template>
+
+<script>
+
+import WeakHardwareOverlay from '@/components/WeakHardwareOverlay';
+export default {
+  components: { WeakHardwareOverlay },
+
+  mounted () {
+    this.player = new Player(this.$refs.player)
+  }
+};
+
+</script>
+
+<style lang="postcss" scoped>
+.nuxt-speedkit-performance-issue-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgb(0 0 0 / 60%);
+  backdrop-filter: blur(2px);
+}
+</style>
+````
+
+
+<br>
+
+

--- a/example/components/atoms/WeakHardwareOverlay.vue
+++ b/example/components/atoms/WeakHardwareOverlay.vue
@@ -1,0 +1,52 @@
+<template>
+  <speedkit-weak-hardware-overlay>
+    <div v-font="$getFont('Montserrat Alternates', 400, 'normal')">
+      <p>{{ text }}</p>
+      <button id="nuxt-speedkit-button-init-app">
+        {{ buttonText }}
+      </button>
+    </div>
+  </speedkit-weak-hardware-overlay>
+</template>
+
+<script>
+
+import SpeedkitWeakHardwareOverlay from 'nuxt-speedkit/components/WeakHardwareOverlay';
+export default {
+  components: { SpeedkitWeakHardwareOverlay },
+
+  props: {
+    text: {
+      type: String,
+      default: 'To improve your experience, extensive features have been disabled.'
+    },
+    buttonText: {
+      type: String,
+      default: 'Click here to enable them.'
+    }
+  }
+
+};
+
+</script>
+
+<style lang="postcss" scoped>
+.nuxt-speedkit-weak-hardware-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  background: rgb(0 0 0 / 60%);
+  backdrop-filter: blur(em(4px));
+
+  & div {
+    font-size: 14px;
+    text-align: center;
+  }
+}
+</style>

--- a/example/components/organisms/VideoVimeo.vue
+++ b/example/components/organisms/VideoVimeo.vue
@@ -9,6 +9,9 @@
       <template #default="{videoData}">
         <div class="description" v-html="videoData && videoData.description" />
       </template>
+      <template #afterPlayer>
+        <weak-hardware-overlay />
+      </template>
     </speedkit-vimeo>
   </document-section>
 </template>
@@ -16,9 +19,10 @@
 <script>
 
 import SpeedkitVimeo from 'nuxt-speedkit/components/SpeedkitVimeo';
+import WeakHardwareOverlay from '@/components/atoms/WeakHardwareOverlay';
 
 export default {
-  components: { SpeedkitVimeo },
+  components: { SpeedkitVimeo, WeakHardwareOverlay },
 
   inheritAttrs: false,
 

--- a/example/components/organisms/VideoYoutube.vue
+++ b/example/components/organisms/VideoYoutube.vue
@@ -5,7 +5,11 @@
     ]"
     class="video-youtube"
   >
-    <speedkit-youtube v-bind="$attrs" />
+    <speedkit-youtube v-bind="$attrs">
+      <template #afterPlayer>
+        <weak-hardware-overlay />
+      </template>
+    </speedkit-youtube>
     <p v-if="text" v-html="text" />
   </document-section>
 </template>
@@ -13,9 +17,10 @@
 <script>
 
 import SpeedkitYoutube from 'nuxt-speedkit/components/SpeedkitYoutube';
+import WeakHardwareOverlay from '@/components/atoms/WeakHardwareOverlay';
 
 export default {
-  components: { SpeedkitYoutube },
+  components: { SpeedkitYoutube, WeakHardwareOverlay },
 
   inheritAttrs: false,
 
@@ -33,4 +38,5 @@ export default {
 .video-youtube {
   padding: 0 10%;
 }
+
 </style>

--- a/example/pages/tests/weak-hardware-overlay/index.vue
+++ b/example/pages/tests/weak-hardware-overlay/index.vue
@@ -1,0 +1,35 @@
+<template>
+  <document-section :class="{mounted}" tag="main">
+    <div>
+      WeakHardwareOverlay
+      <speedkit-weak-hardware-overlay />
+    </div>
+    <speedkit-layer />
+  </document-section>
+</template>
+
+<script>
+import SpeedkitLayer from 'nuxt-speedkit/components/SpeedkitLayer';
+import SpeedkitWeakHardwareOverlay from 'nuxt-speedkit/components/WeakHardwareOverlay';
+
+export default {
+
+  components: {
+    SpeedkitLayer,
+    SpeedkitWeakHardwareOverlay
+  },
+
+  layout: 'blank',
+
+  data () {
+    return {
+      mounted: false
+    };
+  },
+
+  mounted () {
+    this.mounted = true;
+  }
+
+};
+</script>

--- a/lib/components/SpeedkitVimeo.vue
+++ b/lib/components/SpeedkitVimeo.vue
@@ -4,6 +4,9 @@
     v-bind="$attrs"
     v-on="$listeners"
   >
+    <template #beforePlayer>
+      <slot name="beforePlayer" />
+    </template>
     <template #loading-spinner>
       <slot name="loading-spinner">
         <div
@@ -43,6 +46,9 @@
           </span>
         </div>
       </slot>
+    </template>
+    <template #afterPlayer>
+      <slot name="afterPlayer" />
     </template>
     <template #default="context">
       <slot name="default" v-bind="context" />

--- a/lib/components/SpeedkitVimeo/Base.vue
+++ b/lib/components/SpeedkitVimeo/Base.vue
@@ -4,6 +4,7 @@
   >
     <slot name="background" v-bind="{playing, videoData}" />
     <div class="player">
+      <slot name="beforePlayer" />
       <iframe
         ref="player"
         :key="src"
@@ -19,6 +20,7 @@
         <slot v-if="loading" name="loading-spinner" />
         <slot v-if="!ready && !loading" name="play" />
       </default-button>
+      <slot name="afterPlayer" />
     </div>
     <slot v-bind="{playing, videoData}" />
   </div>

--- a/lib/components/SpeedkitYoutube.vue
+++ b/lib/components/SpeedkitYoutube.vue
@@ -1,5 +1,8 @@
 <template>
   <base-youtube class="nuxt-speedkit-youtube" v-bind="$attrs" v-on="$listeners">
+    <template #beforePlayer>
+      <slot name="beforePlayer" />
+    </template>
     <template #loading-spinner>
       <slot name="loading-spinner">
         <svg class="loader loading-spinner" viewBox="0 0 64 64" version="1.1" xmlns="http://www.w3.org/2000/svg">
@@ -31,6 +34,9 @@
           <path d="M 45,24 27,14 27,34" fill="#fff" />
         </svg>
       </slot>
+    </template>
+    <template #afterPlayer>
+      <slot name="afterPlayer" />
     </template>
   </base-youtube>
 </template>
@@ -118,4 +124,5 @@ export default {
 }
 
 /*! purgecss end ignore */
+
 </style>

--- a/lib/components/SpeedkitYoutube/Base.vue
+++ b/lib/components/SpeedkitYoutube/Base.vue
@@ -3,6 +3,7 @@
     :class="{ready, playing}"
     :show="ready"
   >
+    <slot name="beforePlayer" />
     <iframe
       v-if="src"
       ref="player"
@@ -22,6 +23,7 @@
       <slot v-if="loading" name="loading-spinner" />
       <slot v-if="!ready && !loading" name="play" />
     </default-button>
+    <slot name="afterPlayer" />
   </div>
 </template>
 

--- a/lib/components/WeakHardwareOverlay.vue
+++ b/lib/components/WeakHardwareOverlay.vue
@@ -1,21 +1,31 @@
 <template>
-  <div v-if="active" class="nuxt-speedkit-weak-hardware-overlay">
-    <slot>
-      Area is disabled for performance reasons.<br><button id="nuxt-speedkit-button-init-app">
-        Click for activation
-      </button>
-    </slot>
-  </div>
+  <only-ssr>
+    <div class="nuxt-speedkit-weak-hardware-overlay">
+      <slot>
+        Area is disabled for performance reasons.<br><button id="nuxt-speedkit-button-init-app">
+          Click for activation
+        </button>
+      </slot>
+    </div>
+  </only-ssr>
 </template>
 
 <script>
 
+import OnlySsr from 'nuxt-speedkit/components/abstracts/OnlySsr';
+
 export default {
-  data: function () {
-    return {
-      active: process.server
-    };
+  components: {
+    OnlySsr
   }
 };
 
 </script>
+
+<style lang="postcss" scoped>
+.nuxt-speedkit-weak-hardware-overlay {
+  @nest html:not(.nuxt-speedkit-reduced-view) & {
+    display: none;
+  }
+}
+</style>

--- a/lib/components/WeakHardwareOverlay.vue
+++ b/lib/components/WeakHardwareOverlay.vue
@@ -1,0 +1,21 @@
+<template>
+  <div v-if="active" class="nuxt-speedkit-weak-hardware-overlay">
+    <slot>
+      Area is disabled for performance reasons.<br><button id="nuxt-speedkit-button-init-app">
+        Click for activation
+      </button>
+    </slot>
+  </div>
+</template>
+
+<script>
+
+export default {
+  data: function () {
+    return {
+      active: process.server
+    };
+  }
+};
+
+</script>

--- a/test/tests/browser.js
+++ b/test/tests/browser.js
@@ -91,6 +91,8 @@ export default (runtime) => {
 
       await page.evaluate(() => document.querySelector('.nuxt-speedkit-weak-hardware-overlay button').click());
       await page.waitForSelector('main.mounted');
+
+      expect(await page.evaluate(() => document.querySelector('.nuxt-speedkit-weak-hardware-overlay'))).toBeFalsy();
     });
 
     // #endregion /tests/weak-hardware-overlay
@@ -237,7 +239,7 @@ export default (runtime) => {
 
     // #region /tests/iframe
 
-    it('iframe', async () => {
+    it('SpeedkitIframe', async () => {
       const page = await createPage('/iframe/');
       await page.evaluate(() => {
         window.scrollBy(0, window.innerHeight);
@@ -248,7 +250,7 @@ export default (runtime) => {
     // #endregion
 
     // #region /tests/youtube
-    it('youtube ready, play and autoplay', async () => {
+    it('SpeedkitYoutube (ready, play and autoplay)', async () => {
       const page = await createPage('/youtube/');
       await page.waitForLoadState('networkidle');
 
@@ -271,7 +273,7 @@ export default (runtime) => {
 
     // // #region /tests/vimeo
 
-    // it('vimeo ready & play', async () => {
+    // it('SpeedkitVimeo (ready & play)', async () => {
     //   const page = await createPage('/vimeo/');
     //   await page.waitForLoadState('networkidle');
 

--- a/test/tests/browser.js
+++ b/test/tests/browser.js
@@ -70,7 +70,7 @@ export default (runtime) => {
       await page.waitForSelector('[data-font].font-active');
     });
 
-    it('SpeedkitLayer (No Javascript)', async () => {
+    it('SpeedkitLayer (NoJs)', async () => {
       const page = await createPage('/speedkit-layer/', true);
 
       expect(await page.evaluate(() => document.getElementById('nuxt-speedkit-layer'))).not.toBeFalsy();
@@ -81,6 +81,19 @@ export default (runtime) => {
     });
 
     // #endregion /tests/speedkit-layer
+
+    // #region /tests/weak-hardware-overlay
+
+    it('WeakHardwareOverlay (Visible & Init App)', async () => {
+      const page = await createPage('/weak-hardware-overlay/');
+
+      expect(await page.evaluate(() => document.querySelector('.nuxt-speedkit-weak-hardware-overlay'))).not.toBeFalsy();
+
+      await page.evaluate(() => document.querySelector('.nuxt-speedkit-weak-hardware-overlay button').click());
+      await page.waitForSelector('main.mounted');
+    });
+
+    // #endregion /tests/weak-hardware-overlay
 
     // #region /tests/speedkit-loader
 


### PR DESCRIPTION
## Components

### SpeedkitVimeo & SpeedkitYoutbe

- Slots for before player container (`beforePlayer`) and after player container (`afterPlayer`).

### WeakHardwareOverlay

- Added `WeakHardwareOverlay` component. 

## Docs

- Added page for `WeakHardwareOverlay`.
- Updated pages `SpeedkitVimeo` & `SpeedkitYoutube`.

## Tests

- Added test for `WeakHardwareOverlay`.