### PR TITLE
Update option to newest one

### DIFF
--- a/docs/content/v2/en/setup.md
+++ b/docs/content/v2/en/setup.md
@@ -105,7 +105,7 @@ More about `@nuxt/image` module options can be found [here](https://image.nuxtjs
       ]
     }],
 
-    pictureFormats: ['webp', 'avif', 'jpg|jpeg|png|gif'],
+    targetFormats: ['webp', 'avif', 'jpg|jpeg|png|gif'],
 
     componentAutoImport: false,
     componentPrefix: undefined,


### PR DESCRIPTION
WARN  [nuxt-speedkit] Option pictureFormats is deprecated, use targetFormats instead. https://nuxt-speedkit.grabarzundpartner.dev/options#targetformats

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)