### PR TITLE
fix(postcss): replaced deep selector

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -25,6 +25,23 @@
           "vw"
         ]
       }
+    ],
+    "selector-pseudo-class-no-unknown": [
+      true,
+      {
+        "ignorePseudoClasses": [
+          "global",
+          "deep"
+        ]
+      }
+    ],
+    "selector-pseudo-element-no-unknown": [
+      true,
+      {
+        "ignorePseudoElements": [
+          "v-deep"
+        ]
+      }
     ]
   }
 }

--- a/example/components/InfoLayer.vue
+++ b/example/components/InfoLayer.vue
@@ -65,7 +65,7 @@ export default {
 
 <style lang="postcss" scoped>
 .info-layer {
-  & >>> #nuxt-speedkit-layer-content {
+  & :deep(#nuxt-speedkit-layer-content) {
     position: fixed;
     top: 0;
     left: 0;
@@ -95,7 +95,7 @@ export default {
   }
 
   &.nuxt-speedkit-layer-visible {
-    & >>> #nuxt-speedkit-layer-content {
+    & :deep(#nuxt-speedkit-layer-content) {
       animation-delay: initial;
     }
   }

--- a/example/components/organisms/ImageText.vue
+++ b/example/components/organisms/ImageText.vue
@@ -47,12 +47,12 @@ export default {
     padding: 0 10%;
   }
 
-  & >>> img {
+  & :deep(img) {
     width: 100%;
     height: 100%;
   }
 
-  & >>> p {
+  & :deep(p) {
     line-height: 1.6;
   }
 

--- a/example/components/organisms/PreviewContainer.vue
+++ b/example/components/organisms/PreviewContainer.vue
@@ -90,14 +90,13 @@ export default {};
     }
 
     & img,
-    & >>> img,
-    & >>> picture img {
+    & :deep(img, picture img) {
       width: 100%;
       height: 100%;
       object-fit: cover;
     }
 
-    & >>> picture {
+    & :deep(picture) {
       width: 100%;
       height: 100%;
     }
@@ -120,7 +119,7 @@ export default {};
       width: 100%;
       height: 100%;
 
-      & >>> .list {
+      & :deep(.list) {
         padding: 0;
         margin: 0;
         list-style: none;
@@ -130,7 +129,7 @@ export default {};
         }
       }
 
-      & >>> .test-iframe {
+      & :deep(.test-iframe) {
         position: relative;
         width: 100%;
         height: 100%;

--- a/example/components/organisms/Stage.vue
+++ b/example/components/organisms/Stage.vue
@@ -129,7 +129,7 @@ export default {
   & .background {
     aspect-ratio: auto;
 
-    & >>> img {
+    & :deep(img) {
       position: absolute;
       top: 0;
       left: 0;

--- a/example/components/organisms/TextFontA.vue
+++ b/example/components/organisms/TextFontA.vue
@@ -30,7 +30,7 @@ export default {
 .component-text-font-a {
   padding: 0 10%;
 
-  & >>> p {
+  & :deep(p) {
     line-height: 1.6;
   }
 }

--- a/example/components/organisms/TextFontB.vue
+++ b/example/components/organisms/TextFontB.vue
@@ -30,7 +30,7 @@ export default {
 .component-text-font-b {
   padding: 0 10%;
 
-  & >>> p {
+  & :deep(p) {
     line-height: 1.6;
   }
 }

--- a/example/pages/tests/v-font-media/components/Critical.vue
+++ b/example/pages/tests/v-font-media/components/Critical.vue
@@ -56,11 +56,11 @@ export default {
 <style lang="postcss" scoped>
 .preview-container {
   @media (max-width: 767px) {
-    & >>> .preview {
+    & :deep(.preview) {
       height: 70vh;
     }
 
-    & >>> .info {
+    & :deep(.info) {
       height: 30vh;
     }
   }

--- a/example/pages/tests/v-font-media/components/Lazy.vue
+++ b/example/pages/tests/v-font-media/components/Lazy.vue
@@ -56,11 +56,11 @@ export default {
 <style lang="postcss" scoped>
 .preview-container {
   @media (max-width: 767px) {
-    & >>> .preview {
+    & :deep(.preview) {
       height: 70vh;
     }
 
-    & >>> .info {
+    & :deep(.info) {
       height: 30vh;
     }
   }

--- a/example/pages/tests/v-font/components/Critical.vue
+++ b/example/pages/tests/v-font/components/Critical.vue
@@ -64,11 +64,11 @@ export default {
 <style lang="postcss" scoped>
 .preview-container {
   @media (max-width: 767px) {
-    & >>> .preview {
+    & :deep(.preview) {
       height: 70vh;
     }
 
-    & >>> .info {
+    & :deep(.info) {
       height: 30vh;
     }
   }

--- a/example/pages/tests/v-font/components/Lazy.vue
+++ b/example/pages/tests/v-font/components/Lazy.vue
@@ -66,11 +66,11 @@ export default {
 <style lang="postcss" scoped>
 .preview-container {
   @media (max-width: 767px) {
-    & >>> .preview {
+    & :deep(.preview) {
       height: 70vh;
     }
 
-    & >>> .info {
+    & :deep(.info) {
       height: 30vh;
     }
   }

--- a/lib/components/SpeedkitVimeo.vue
+++ b/lib/components/SpeedkitVimeo.vue
@@ -85,7 +85,7 @@ export default {
   }
 }
 
->>> button {
+:deep(button) {
   --color-background: rgb(30 30 30 / 70%);
   --color-foreground: #fff;
   --transition-duration: 0.1s;

--- a/lib/components/SpeedkitYoutube.vue
+++ b/lib/components/SpeedkitYoutube.vue
@@ -67,7 +67,7 @@ export default {
   }
 }
 
->>> button {
+:deep(button) {
   --color-background: #212121;
   --color-foreground: #fff;
   --transition-duration: 0.1s;


### PR DESCRIPTION
> [@vue/compiler-sfc] the >>> and /deep/ combinators have been deprecated. Use :deep() instead.
