### PR TITLE
fix(source): fix external `baseUrl`

### DIFF
--- a/lib/components/SpeedkitImage/utils/image.js
+++ b/lib/components/SpeedkitImage/utils/image.js
@@ -48,7 +48,7 @@ export const getMeta = async (source, compiledSrc, ssrNuxtImage) => {
     if (Object.entries(ssrNuxtImage || {}).length) {
       src = Object.entries(ssrNuxtImage || {}).find(([, compiledPath]) => compiledPath.endsWith(src))[0];
     }
-    source = source.modify({ src: !hasProtocol(src) ? withBase(src, process.env.NUXT_SPEEDKIT_INTERAL_URL) : src });
+    source = source.modify({ src: hasProtocol(src) ? src : withBase(src, process.env.NUXT_SPEEDKIT_INTERAL_URL) });
     const resp = await fetch(source.src);
     const sizeOf = (await import('buffer-image-size')).default;
     const { width, height } = sizeOf(await resp.buffer());

--- a/lib/components/SpeedkitImage/utils/image.js
+++ b/lib/components/SpeedkitImage/utils/image.js
@@ -1,4 +1,4 @@
-import { joinURL, parseURL } from 'ufo';
+import { joinURL, parseURL, withBase, hasProtocol } from 'ufo';
 
 const SOURCE_FORMATS = ['avif', 'webp', 'png', 'jpg', 'gif'];
 const FALLBACK_FORMAT = 'jpg';
@@ -48,7 +48,7 @@ export const getMeta = async (source, compiledSrc, ssrNuxtImage) => {
     if (Object.entries(ssrNuxtImage || {}).length) {
       src = Object.entries(ssrNuxtImage || {}).find(([, compiledPath]) => compiledPath.endsWith(src))[0];
     }
-    source = source.modify({ src: joinURL(process.env.NUXT_SPEEDKIT_INTERAL_URL, src) });
+    source = source.modify({ src: !hasProtocol(src) ? withBase(src, process.env.NUXT_SPEEDKIT_INTERAL_URL) : src });
     const resp = await fetch(source.src);
     const sizeOf = (await import('buffer-image-size')).default;
     const { width, height } = sizeOf(await resp.buffer());


### PR DESCRIPTION
Do not add internal url if src already has a protocol.

Occurs with External Provider.