### PR TITLE
fix(hydrate): add max idle tries for `speedkitHydrate`

### DIFF
--- a/docs/content/v2/en/options.md
+++ b/docs/content/v2/en/options.md
@@ -295,17 +295,22 @@ Defines the global built-in [LoadingSpinner](/components/speedkit-image#loadings
  | `size`            | `String` | no       | Defines the size of the loader. Use css `background-size` definition.         | `100px`     |
  | `backgroundColor` | `String` | no       | Defines the background color of the loader. Use css `color` definition.       | `grey`      |
 
-## `maxIdleDuration`
-- Type: `Number`
-  - Default: `16`
+## `maxIdleDurations`
+- Type: `Object`
 
 Defines the duration (seconds), which is tried to determine a free slot by `IdleDeadline.timeRemaining()`. Free slot must be at least `10ms`.
 
-When reaching the max. value, 
+````js
+{
+  entry: 16,
+  hyrdate: 8
+}
+````
 
-- the SpeedkitLayer is shown if available or the app is 
-- or the app is initialized automatically.
-
+ | Key       | Type     | Required | Description                                                                                                                                                                           | Default |
+ | --------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+ | `entry`   | `Number` | yes      | Refers to the initialization of the main javascript. <br>When reaching the max. value, the SpeedkitLayer is shown if available or the app is or the app is initialized automatically. | `16`    |
+ | `hyrdate` | `Number` | yes      | Refers to the initialization of components import with `speedkitHydrate`.                                                                                                             | `8`     |
 
 ## `disableNuxtImage`
 - Type: `Boolean`

--- a/lib/hydrate.js
+++ b/lib/hydrate.js
@@ -1,6 +1,12 @@
 
 import { hydrateWhenVisible } from 'vue-lazy-hydration';
 
+function getMaxIdleTries () {
+  return global.__NUXT_SPEEDKIT_HYDRATE_MAX_IDLE_DURATION__ * 60;
+}
+
+const MAX_IDLE_TRIES = getMaxIdleTries();
+
 const isDev = process.env.NODE_ENV === 'development';
 
 let idleExecuteResolve = true;
@@ -36,17 +42,24 @@ const wrap = (component, executeResolve) => {
 
 const execute = (component) => {
   return new Promise((resolve) => {
-    if ('requestIdleCallback' in global) {
-      global.requestIdleCallback((deadline) => {
-        const time = deadline.timeRemaining();
-        if (time > 10 || deadline.didTimeout) {
-          resolve(component);
-        } else {
-          resolve(execute(component));
-        }
-      }, { timeout: 2000 });
-    } else {
-      resolve(component);
-    }
+    return waitForIdle(() => resolve(component));
   });
 };
+
+function waitForIdle (cb, idleTries = 0) {
+  if (idleTries >= MAX_IDLE_TRIES) {
+    cb();
+  } else if ('requestIdleCallback' in global && MAX_IDLE_TRIES > idleTries) {
+    idleTries++;
+    global.requestIdleCallback((deadline) => {
+      const time = deadline.timeRemaining();
+      if (time > 10 || deadline.didTimeout) {
+        cb();
+      } else {
+        waitForIdle(cb, idleTries);
+      }
+    }, { timeout: 2000 });
+  } else {
+    cb();
+  }
+}

--- a/lib/module.js
+++ b/lib/module.js
@@ -79,7 +79,7 @@ async function addBuildTemplates (scope, options) {
     src: path.resolve(__dirname, 'templates/entry.js'),
     fileName: pkg.name + '/entry.js',
     options: {
-      maxIdleDuration: options.maxIdleDuration,
+      maxIdleDurations: options.maxIdleDurations,
       ssr: scope.nuxt.options.ssr,
       ignorePerformance: !options.detection.performance,
       performanceMetrics: JSON.stringify(options.performanceMetrics || {}),

--- a/lib/module/utils.js
+++ b/lib/module/utils.js
@@ -19,6 +19,12 @@ function getOptions (options) {
     consola.warn(`[${pkg.name}] Option \`pictureFormats\` is deprecated, use \`targetFormats\` instead. \`https://nuxt-speedkit.grabarzundpartner.dev/options#targetformats\``);
     options.targetFormats = options.pictureFormats;
   }
+  if ('maxIdleDuration' in options) {
+    consola.warn(`[${pkg.name}] Option \`maxIdleDuration\` is deprecated, use \`maxIdleDurations\` instead. \`https://nuxt-speedkit.grabarzundpartner.dev/options#maxidledurations\``);
+    options.maxIdleDurations = {
+      entry: options.maxIdleDuration, hyrdate: 8
+    };
+  }
 
   options = defu(options, {
 
@@ -59,7 +65,10 @@ function getOptions (options) {
       backgroundColor: 'grey'
     },
 
-    maxIdleDuration: 16
+    maxIdleDurations: {
+      entry: 16,
+      hydrate: 8
+    }
   });
   options.targetFormats = options.targetFormats || DEFAULT_TARGET_FORMATS;
   return options;

--- a/lib/templates/entry.js
+++ b/lib/templates/entry.js
@@ -1,10 +1,13 @@
 import { hasSufficientPerformance, hasSufficientDownloadPerformance, setup } from 'nuxt-speedkit/utils/performance';
 import { isSupportedBrowser } from 'nuxt-speedkit/utils/browser';
 
+
+global.__NUXT_SPEEDKIT_HYDRATE_MAX_IDLE_DURATION__ = <%= options.maxIdleDurations.hydrate %>;
+
 function getMaxIdleTries () {
-  let duration = <%= options.maxIdleDuration %>;
-  if (window.__NUXT_SPEEDKIT_MAX_IDLE_DURATION__ !== undefined) {
-    duration = window.__NUXT_SPEEDKIT_MAX_IDLE_DURATION__;
+  let duration = <%= options.maxIdleDurations.entry %>;
+  if (global.__NUXT_SPEEDKIT_MAX_IDLE_DURATION__ !== undefined) {
+    duration = global.__NUXT_SPEEDKIT_MAX_IDLE_DURATION__;
   }
   return duration * 60;
 }


### PR DESCRIPTION
A max. idle duration has been added to `speedkitHydrate`.

For this the option `maxIdleDuration` was replaced by `maxIdleDurations`.

In the property `maxIdleDurations` the max. idle duration for the entry (`entry`) and for speedkitHyrdate `hyrdate` is set. 