### PR TITLE
fix(vimeo): fix wrong embed url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Project Changelog
 
+## [2.0.20](https://github.com/GrabarzUndPartner/nuxt-speedkit/compare/v2.0.19...v2.0.20) (2022-08-21)
+
+
+### Bug Fixes
+
+* **source:** fix external `basePath` ([31a4522](https://github.com/GrabarzUndPartner/nuxt-speedkit/commit/31a45229c79566ced024758c6b5aee0a54354692))
+
 ## [2.0.19](https://github.com/GrabarzUndPartner/nuxt-speedkit/compare/v2.0.18...v2.0.19) (2022-08-21)
 
 

--- a/docs/content/v2/en/components/speedkit-vimeo.md
+++ b/docs/content/v2/en/components/speedkit-vimeo.md
@@ -11,7 +11,7 @@ So that no empty space is visible to the user, we use the functionality of the [
 
 ## Usage
 
-The `SpeedkitVimeo`is used to initialise Vimeo videos with [`Vimeo Player-SDK`](https://developer.vimeo.com/player/sdk/).  
+The `SpeedkitVimeo` is used to initialise Vimeo videos with [`Vimeo Player-SDK`](https://developer.vimeo.com/player/sdk/).  
 <alert>The SDK is not part of `nuxt-speedkit` and will be loaded by an external script.</alert>
 
 The `url` of the Vimeo video must be specified.  
@@ -42,7 +42,7 @@ export default {
         title: 'Vimeo Title',
         loadingSpinner: undefined,
         options: {
-          controls: false // use boolean instead of 0 or 1
+          controls: false
         },
         posterSizes: {
           default: '100vw',
@@ -113,8 +113,6 @@ Sets the image sizes of the poster.
 - Type: `Object`
 
 Overrides the vimeo player options. These will be the same as the vimeo player embed options.
-
-Use `boolean` values instead of integers (e.g. `0`, `1`).
 
 [Learn more about Vimeo Player Parameters](https://developer.vimeo.com/player/sdk/embed)
 

--- a/lib/components/SpeedkitVimeo/Base.vue
+++ b/lib/components/SpeedkitVimeo/Base.vue
@@ -113,7 +113,8 @@ export default {
       const url = withQuery('https://vimeo.com/api/oembed.json', {
         url: this.url,
         width: 1920,
-        height: 1080
+        height: 1080,
+        ...this.playerOptions
       });
       const { data } = await get(url);
       this.videoData = data;
@@ -135,6 +136,21 @@ export default {
       return this.title || (this.videoData && this.videoData.title);
     },
 
+    playerOptions () {
+      return {
+        dnt: true,
+        autopause: false,
+        ...this.options,
+        playsinline: true,
+        autoplay: this.autoplay,
+        muted: this.isTouchDevice || this.mute
+      };
+    },
+
+    playerSrc () {
+      return this.videoData?.html.replace(/.*src="([^"]*)".*/, '$1').replace(/&amp;/g, '&') || `https://player.vimeo.com/video/${this.videoId}`;
+    },
+
     pictureComponent () {
       return this.videoData ? SpeedkitPicture : 'picture';
     },
@@ -154,19 +170,6 @@ export default {
         }],
         loadingSpinner: this.posterLoadingSpinner
       };
-    },
-
-    playerSrc () {
-      const params = {
-        dnt: 1,
-        autopause: 0,
-        ...this.options,
-        playsinline: 1,
-        autoplay: Number(this.autoplay),
-        muted: Number(this.isTouchDevice || this.mute || false)
-      };
-
-      return `https://player.vimeo.com/video/${this.videoId}?` + Object.entries(params).map(([name, value]) => `${name}=${value}`).join('&');
     }
 
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nuxt-speedkit",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nuxt-speedkit",
-      "version": "2.0.19",
+      "version": "2.0.20",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-speedkit",
-  "version": "2.0.19",
+  "version": "2.0.20",
   "description": "Nuxt Speedkit takes over the Lighthouse performance optimization of your generated website.",
   "license": "MIT",
   "contributors": [

--- a/test/tests/browser.js
+++ b/test/tests/browser.js
@@ -256,39 +256,39 @@ export default (runtime) => {
 
     // #endregion
 
-    // // #region /tests/vimeo
+    // #region /tests/vimeo
 
-    // it('vimeo ready & play', async () => {
-    //   const page = await createPage('/vimeo/');
-    //   await page.waitForLoadState('networkidle');
+    it('vimeo ready & play', async () => {
+      const page = await createPage('/vimeo/');
+      await page.waitForLoadState('networkidle');
 
-    //   // Other Vimeo tests not working in chromium, codec H.264 is unsupport
-    //   if (browser === BROWSERS.CHROMIUM) {
-    //     // start first player
-    //     await page.evaluate(() => document.querySelector('#vimeo-0 button').click());
-    //     await page.waitForLoadState('networkidle');
+      // Other Vimeo tests not working in chromium, codec H.264 is unsupport
+      if (browser === BROWSERS.CHROMIUM) {
+        // start first player
+        await page.evaluate(() => document.querySelector('#vimeo-0 button').click());
+        await page.waitForLoadState('networkidle');
 
-    //     // wait for player ready
-    //     await page.waitForSelector('#vimeo-0 .nuxt-speedkit-vimeo.ready');
-    //   } else {
-    //     // start first player
-    //     await page.evaluate(() => document.querySelector('#vimeo-0 button').click());
-    //     await page.waitForLoadState('networkidle');
+        // wait for player ready
+        await page.waitForSelector('#vimeo-0 .nuxt-speedkit-vimeo.ready');
+      } else {
+        // start first player
+        await page.evaluate(() => document.querySelector('#vimeo-0 button').click());
+        await page.waitForLoadState('networkidle');
 
-    //     // wait for playing first player playing
-    //     await page.waitForSelector('#vimeo-0 .nuxt-speedkit-vimeo.ready.playing');
+        // wait for playing first player playing
+        await page.waitForSelector('#vimeo-0 .nuxt-speedkit-vimeo.ready.playing');
 
-    //     // // wait for playing first player playing
-    //     await page.evaluate(() => window.scrollBy(0, window.innerHeight));
-    //     // // start second player
-    //     await page.evaluate(() => document.querySelector('#vimeo-1 button').click());
-    //     await page.waitForLoadState('networkidle');
+        // // wait for playing first player playing
+        await page.evaluate(() => window.scrollBy(0, window.innerHeight));
+        // // start second player
+        await page.evaluate(() => document.querySelector('#vimeo-1 button').click());
+        await page.waitForLoadState('networkidle');
 
-    //     await page.waitForSelector('#vimeo-0 .nuxt-speedkit-vimeo.ready:not(.playing)');
-    //     await page.waitForSelector('#vimeo-1 .nuxt-speedkit-vimeo.ready.playing');
-    //   }
-    // });
+        await page.waitForSelector('#vimeo-0 .nuxt-speedkit-vimeo.ready:not(.playing)');
+        await page.waitForSelector('#vimeo-1 .nuxt-speedkit-vimeo.ready.playing');
+      }
+    });
 
-    // // #endregion
+    // #endregion
   }
 };

--- a/test/tests/browser.js
+++ b/test/tests/browser.js
@@ -256,39 +256,39 @@ export default (runtime) => {
 
     // #endregion
 
-    // #region /tests/vimeo
+//     // #region /tests/vimeo
 
-    it('vimeo ready & play', async () => {
-      const page = await createPage('/vimeo/');
-      await page.waitForLoadState('networkidle');
+//     it('vimeo ready & play', async () => {
+//       const page = await createPage('/vimeo/');
+//       await page.waitForLoadState('networkidle');
 
-      // Other Vimeo tests not working in chromium, codec H.264 is unsupport
-      if (browser === BROWSERS.CHROMIUM) {
-        // start first player
-        await page.evaluate(() => document.querySelector('#vimeo-0 button').click());
-        await page.waitForLoadState('networkidle');
+//       // Other Vimeo tests not working in chromium, codec H.264 is unsupport
+//       if (browser === BROWSERS.CHROMIUM) {
+//         // start first player
+//         await page.evaluate(() => document.querySelector('#vimeo-0 button').click());
+//         await page.waitForLoadState('networkidle');
 
-        // wait for player ready
-        await page.waitForSelector('#vimeo-0 .nuxt-speedkit-vimeo.ready');
-      } else {
-        // start first player
-        await page.evaluate(() => document.querySelector('#vimeo-0 button').click());
-        await page.waitForLoadState('networkidle');
+//         // wait for player ready
+//         await page.waitForSelector('#vimeo-0 .nuxt-speedkit-vimeo.ready');
+//       } else {
+//         // start first player
+//         await page.evaluate(() => document.querySelector('#vimeo-0 button').click());
+//         await page.waitForLoadState('networkidle');
 
-        // wait for playing first player playing
-        await page.waitForSelector('#vimeo-0 .nuxt-speedkit-vimeo.ready.playing');
+//         // wait for playing first player playing
+//         await page.waitForSelector('#vimeo-0 .nuxt-speedkit-vimeo.ready.playing');
 
-        // // wait for playing first player playing
-        await page.evaluate(() => window.scrollBy(0, window.innerHeight));
-        // // start second player
-        await page.evaluate(() => document.querySelector('#vimeo-1 button').click());
-        await page.waitForLoadState('networkidle');
+//         // // wait for playing first player playing
+//         await page.evaluate(() => window.scrollBy(0, window.innerHeight));
+//         // // start second player
+//         await page.evaluate(() => document.querySelector('#vimeo-1 button').click());
+//         await page.waitForLoadState('networkidle');
 
-        await page.waitForSelector('#vimeo-0 .nuxt-speedkit-vimeo.ready:not(.playing)');
-        await page.waitForSelector('#vimeo-1 .nuxt-speedkit-vimeo.ready.playing');
-      }
-    });
+//         await page.waitForSelector('#vimeo-0 .nuxt-speedkit-vimeo.ready:not(.playing)');
+//         await page.waitForSelector('#vimeo-1 .nuxt-speedkit-vimeo.ready.playing');
+//       }
+//     });
 
-    // #endregion
+//     // #endregion
   }
 };

--- a/test/tests/browser.js
+++ b/test/tests/browser.js
@@ -63,8 +63,7 @@ export default (runtime) => {
       await page.evaluate(() => document.getElementById('nuxt-speedkit-button-init-app').click());
       await page.waitForLoadState('networkidle');
 
-      // picture transformed
-      await page.waitForSelector('.nuxt-speedkit-picture');
+      await page.waitForSelector('.ready');
 
       // active font
       await page.waitForSelector('[data-font].font-active');
@@ -256,39 +255,39 @@ export default (runtime) => {
 
     // #endregion
 
-//     // #region /tests/vimeo
+    // // #region /tests/vimeo
 
-//     it('vimeo ready & play', async () => {
-//       const page = await createPage('/vimeo/');
-//       await page.waitForLoadState('networkidle');
+    // it('vimeo ready & play', async () => {
+    //   const page = await createPage('/vimeo/');
+    //   await page.waitForLoadState('networkidle');
 
-//       // Other Vimeo tests not working in chromium, codec H.264 is unsupport
-//       if (browser === BROWSERS.CHROMIUM) {
-//         // start first player
-//         await page.evaluate(() => document.querySelector('#vimeo-0 button').click());
-//         await page.waitForLoadState('networkidle');
+    //   // Other Vimeo tests not working in chromium, codec H.264 is unsupport
+    //   if (browser === BROWSERS.CHROMIUM) {
+    //     // start first player
+    //     await page.evaluate(() => document.querySelector('#vimeo-0 button').click());
+    //     await page.waitForLoadState('networkidle');
 
-//         // wait for player ready
-//         await page.waitForSelector('#vimeo-0 .nuxt-speedkit-vimeo.ready');
-//       } else {
-//         // start first player
-//         await page.evaluate(() => document.querySelector('#vimeo-0 button').click());
-//         await page.waitForLoadState('networkidle');
+    //     // wait for player ready
+    //     await page.waitForSelector('#vimeo-0 .nuxt-speedkit-vimeo.ready');
+    //   } else {
+    //     // start first player
+    //     await page.evaluate(() => document.querySelector('#vimeo-0 button').click());
+    //     await page.waitForLoadState('networkidle');
 
-//         // wait for playing first player playing
-//         await page.waitForSelector('#vimeo-0 .nuxt-speedkit-vimeo.ready.playing');
+    //     // wait for playing first player playing
+    //     await page.waitForSelector('#vimeo-0 .nuxt-speedkit-vimeo.ready.playing');
 
-//         // // wait for playing first player playing
-//         await page.evaluate(() => window.scrollBy(0, window.innerHeight));
-//         // // start second player
-//         await page.evaluate(() => document.querySelector('#vimeo-1 button').click());
-//         await page.waitForLoadState('networkidle');
+    //     // // wait for playing first player playing
+    //     await page.evaluate(() => window.scrollBy(0, window.innerHeight));
+    //     // // start second player
+    //     await page.evaluate(() => document.querySelector('#vimeo-1 button').click());
+    //     await page.waitForLoadState('networkidle');
 
-//         await page.waitForSelector('#vimeo-0 .nuxt-speedkit-vimeo.ready:not(.playing)');
-//         await page.waitForSelector('#vimeo-1 .nuxt-speedkit-vimeo.ready.playing');
-//       }
-//     });
+    //     await page.waitForSelector('#vimeo-0 .nuxt-speedkit-vimeo.ready:not(.playing)');
+    //     await page.waitForSelector('#vimeo-1 .nuxt-speedkit-vimeo.ready.playing');
+    //   }
+    // });
 
-//     // #endregion
+    // // #endregion
   }
 };


### PR DESCRIPTION
The embed url for iframe has been causing problems with the passed options until now.

This has been solved by using the `src` from the supplied iframe in the embed api call. Here a hash is used per player configuration for matching.