### PR TITLE
fix(intersection): fix element-observer inView state

### DIFF
--- a/lib/classes/intersection/ElementObserver.js
+++ b/lib/classes/intersection/ElementObserver.js
@@ -24,9 +24,9 @@ export default class ElementObserver {
   }
 
   onIntersecting (isIntersecting) {
-    this.#inView = isIntersecting;
     if (isIntersecting) {
       this.#inViewDeferrer.resolve();
+      this.#inView = true;
       this.#inViewListeners.forEach(listener => listener());
     } else if (this.#inView) {
       this.#outViewDeferrer.resolve();


### PR DESCRIPTION
Fix the `inView` state from the `ElementObserver`, this could not reach the leave.