### PR TITLE
fix(v-font): added isCritical check in inserted

### DIFF
--- a/lib/plugins/vFont/directive.js
+++ b/lib/plugins/vFont/directive.js
@@ -19,7 +19,7 @@ export default {
       },
 
       async inserted (el, binding, vnode) {
-        if (!isElementOutViewport(el)) {
+        if (vnode.context.isCritical || !isElementOutViewport(el)) {
           activateFonts(el, binding, vnode);
         } else {
           const observer = getElementObserver(el, {


### PR DESCRIPTION
If `critical` is already set, there is no need to wait for the IntersectionObserver.