### PR TITLE
fix(entry): added customEvent for idle waiting duration

### DIFF
--- a/lib/templates/entry.js
+++ b/lib/templates/entry.js
@@ -15,6 +15,7 @@ function getMaxIdleTries () {
 
 const MAX_IDLE_TRIES = getMaxIdleTries();
 
+let startTime;
 let init = false
 const layerEl = global.document.getElementById('nuxt-speedkit-layer');
 
@@ -25,7 +26,10 @@ async function initApp(force) {
 
   document.documentElement.classList.remove('nuxt-speedkit-reduced-view');
 
-  init = force || await new Promise(resolve => waitForIdle(resolve));
+  init = force || await new Promise(resolve => {
+    startTime = window.performance.now();
+    waitForIdle(resolve);
+  });
   if (init) {
     return import(<% if (!options.ssr) { %>/* webpackMode: "eager" */<% } %>'../client');
   }
@@ -42,6 +46,11 @@ function waitForIdle (cb) {
   } else if ('requestIdleCallback' in global &&  MAX_IDLE_TRIES > idleTries) {
     idleTries++
     global.requestIdleCallback((deadline) => {
+      window.dispatchEvent(new CustomEvent('nuxtSpeedkitWaitingIdleCallback', {
+        detail: {
+          duration: window.performance.now() - startTime
+        }
+      }))
       const time = deadline.timeRemaining();
       if (time > 10 || deadline.didTimeout) {
         cb(true);


### PR DESCRIPTION
CustomEvent `nuxtSpeedkitWaitingIdleCallback` added.

Can be used to listen on the wait duration of the entry.